### PR TITLE
Utlize redis as cooldown thingy and use only one connection to tmi

### DIFF
--- a/src/CreateEnv.ts
+++ b/src/CreateEnv.ts
@@ -74,7 +74,7 @@ export const Setup = {
 
 		const self = await Channel.CreateBot();
 
-		await twitch.client.join(Bot.Config.BotUsername);
+		await twitch.join(Bot.Config.BotUsername);
 		twitch.channels.push(self);
 
 		const channels = await Bot.SQL.selectFrom('channels')
@@ -88,7 +88,7 @@ export const Setup = {
 
 			Bot.Log.Info(`Twitch Joining %s`, channel.name);
 			try {
-				await twitch.client.join(channel.name);
+				await twitch.join(channel.name);
 			} catch (error) {
 				Bot.Log.Error(error as Error, `Joining ${channel.name}`);
 				mode = 'Read'; // We want to create a channel object, but since we can't join, we set the mode to read

--- a/src/CreateEnv.ts
+++ b/src/CreateEnv.ts
@@ -93,8 +93,8 @@ export const Setup = {
 				Bot.Log.Error(error as Error, `Joining ${channel.name}`);
 				mode = 'Read'; // We want to create a channel object, but since we can't join, we set the mode to read
 			}
-			const isLive = await GetChannelData(channel.user_id, 'IsLive');
-			const newChannel = await Channel.New(user, mode, isLive.ToBoolean());
+
+			const newChannel = await Channel.New(user, mode);
 
 			twitch.channels.push(newChannel);
 		}

--- a/src/CreateEnv.ts
+++ b/src/CreateEnv.ts
@@ -69,7 +69,7 @@ export const Setup = {
 
 		await TimerSingleton.I().Initialize();
 
-		await Bot.Twitch.Controller.InitPromise;
+		await Bot.Twitch.Controller.InitReady;
 		const twitch = Bot.Twitch.Controller;
 
 		const self = await Channel.CreateBot();

--- a/src/Models/Command.ts
+++ b/src/Models/Command.ts
@@ -107,10 +107,6 @@ export interface CommandModel<Mods extends object = object> {
 	 */
 	readonly Permission: EPermissionLevel; // FIXME: Remove this
 	/**
-	 * If command can only be run while streamer is offline
-	 */
-	readonly OnlyOffline: boolean;
-	/**
 	 * Other words which trigger this command
 	 */
 	readonly Aliases: string[];

--- a/src/Singletons/Redis/EventSub/StreamOffline.ts
+++ b/src/Singletons/Redis/EventSub/StreamOffline.ts
@@ -15,7 +15,5 @@ export default {
 		}
 
 		await UpdateChannelData(broadcaster_user_id, 'IsLive', new DataStoreContainer('false'));
-
-		await channel.UpdateLive();
 	},
 } as IEventSubHandler<IPubStreamOffline>;

--- a/src/Singletons/Redis/EventSub/StreamOnline.ts
+++ b/src/Singletons/Redis/EventSub/StreamOnline.ts
@@ -20,7 +20,5 @@ export default {
 		}
 
 		await UpdateChannelData(broadcaster_user_id, 'IsLive', new DataStoreContainer('true'));
-
-		await channel.UpdateLive();
 	},
 } as IEventSubHandler<IPubStreamOnline>;

--- a/src/Twitch.ts
+++ b/src/Twitch.ts
@@ -167,7 +167,6 @@ export default class Twitch {
 
 		const channel = this.channels.find((chl) => chl.LowercaseName === channelName);
 
-		// This would never happen, but typescript rules..
 		if (!channel) return;
 
 		try {
@@ -183,14 +182,8 @@ export default class Twitch {
 			if (!messageText.toLocaleLowerCase().startsWith(Bot.Config.Prefix)) {
 				return;
 			}
-			/*
-                Checks if mode is read, allows the owner to use commands there.
-                Or if the command is in the filter.
-            */
-			if (
-				(channel.Mode === 'Read' && user.TwitchUID !== Bot.Config.OwnerUserID) ||
-				channel.Filter.includes(input[1])
-			) {
+
+			if (channel.Mode === 'Read' && user.TwitchUID !== Bot.Config.OwnerUserID) {
 				return;
 			}
 

--- a/src/Twitch.ts
+++ b/src/Twitch.ts
@@ -103,7 +103,7 @@ export default class Twitch {
 	}
 
 	async AddChannelList(user: User): Promise<Channel> {
-		const c = await Channel.New(user, 'Write', false);
+		const c = await Channel.New(user, 'Write');
 		this.channels.push(c);
 		return c;
 	}

--- a/src/Twitch.ts
+++ b/src/Twitch.ts
@@ -181,17 +181,13 @@ export default class Twitch {
 	// }
 
 	private async OnTMIError(error: Error) {
-		if (error instanceof DankTwitch.ConnectionError) {
+		if (
+			error instanceof DankTwitch.ConnectionError ||
+			error.message.includes('Error occured in transport layer')
+		) {
 			// Ignore, as this is caused by the firehose server going down
 
 			return;
-		}
-
-		if (
-			error instanceof DankTwitch.JoinError &&
-			error.message.includes('Error occured in transport layer')
-		) {
-			return; // Firehose server is not yet up, dt-irc tried to connect
 		}
 
 		Bot.Log.Error(error, 'TMI Error');

--- a/src/Typings/enums.ts
+++ b/src/Typings/enums.ts
@@ -1,6 +1,7 @@
 export enum ECommandFlags {
 	NoBanphrase = 'no-banphrase',
 	ResponseIsReply = 'response-is-reply',
+	OnlyOffline = 'only-offline',
 }
 
 export enum EPermissionLevel {

--- a/src/commands/7tv/index.ts
+++ b/src/commands/7tv/index.ts
@@ -12,7 +12,6 @@ registerCommand({
 	Name: '7tv',
 	Description: 'Search 7TV emotes',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 5,
 	Params: [

--- a/src/commands/7tvu/index.ts
+++ b/src/commands/7tvu/index.ts
@@ -54,7 +54,6 @@ registerCommand({
 	Name: '7tvu',
 	Description: 'Display information about a 7TV user',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 5,
 	Params: [],

--- a/src/commands/PotFriend/index.ts
+++ b/src/commands/PotFriend/index.ts
@@ -16,7 +16,6 @@ registerCommand({
 	Name: 'PotFriend',
 	Description: 'PotFriend tells you an advice',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 5,
 	Params: [],

--- a/src/commands/add/index.ts
+++ b/src/commands/add/index.ts
@@ -36,10 +36,8 @@ const getEmoteFromID = (name: string | undefined) => {
 
 registerCommand<PreHandlers>({
 	Name: 'add',
-	Ping: false,
 	Description: 'Add a 7TV emote',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 5,
 	Params: [

--- a/src/commands/alias/index.ts
+++ b/src/commands/alias/index.ts
@@ -11,7 +11,6 @@ registerCommand<PreHandlers>({
 	Name: 'alias',
 	Description: "Sets the alias of an emote, don't give it a name and it will remove the alias",
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 5,
 	Params: [],

--- a/src/commands/editor/index.ts
+++ b/src/commands/editor/index.ts
@@ -18,7 +18,6 @@ registerCommand<PreHandlers>({
 	Name: 'editor',
 	Description: 'Allows the bot to add and remove users as 7TV editors',
 	Permission: EPermissionLevel.BROADCAST,
-	OnlyOffline: false,
 	Aliases: ['adde', 'addeditor', 'removee', 'removeeditor'],
 	Cooldown: 5,
 	Params: [],

--- a/src/commands/github/index.ts
+++ b/src/commands/github/index.ts
@@ -5,7 +5,6 @@ registerCommand({
 	Name: 'github',
 	Description: 'Shows the git repo',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: ['git'],
 	Cooldown: 10,
 	Params: [],

--- a/src/commands/help/index.ts
+++ b/src/commands/help/index.ts
@@ -6,7 +6,6 @@ registerCommand({
 	Name: 'help',
 	Description: 'Prints out the description of a command or the website if nothing was specified',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: ['commands'],
 	Cooldown: 5,
 	Params: [],

--- a/src/commands/hint/index.ts
+++ b/src/commands/hint/index.ts
@@ -6,7 +6,6 @@ registerCommand({
 	Ping: false,
 	Description: 'Displays the trivia hint.',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 5,
 	Params: [],

--- a/src/commands/join/index.ts
+++ b/src/commands/join/index.ts
@@ -31,9 +31,6 @@ registerCommand({
 			};
 		}
 
-		const response = (pronoun: string) =>
-			`Joining ${pronoun} channel. :) Remember to read 👉 https://twitch.tv/${Bot.Config.BotUsername}/about for info on setting me up.`;
-
 		let other = false;
 		let channel = ctx.user;
 		const otherUser = ctx.input[0];
@@ -81,26 +78,25 @@ registerCommand({
 			};
 		}
 
-		return await Channel.Join(channel)
-			.then(() => {
-				if (!other) {
-					return {
-						Success: true,
-						Result: response('your'),
-					};
-				}
+		const pronoun = other ? channel.Name + "'s" : 'your';
 
-				return {
-					Success: true,
-					Result: response(`${channel.Name}'s`),
-				};
-			})
-			.catch(() => {
-				return {
-					Success: false,
-					Result: 'Something went wrong :(',
-				};
-			});
+		const response = `Joining ${pronoun} channel. :) Remember to read 👉 https://twitch.tv/${Bot.Config.BotUsername}/about for info on setting me up.`;
+
+		try {
+			await Channel.Join(channel);
+
+			return {
+				Success: true,
+				Result: response,
+			};
+		} catch (error) {
+			ctx.Log('error', 'Failed to join channel', error);
+
+			return {
+				Success: false,
+				Result: 'Something went wrong :/',
+			};
+		}
 	},
 	LongDescription: async (prefix) => [
 		`Join a channel. Works only in bots channel`,

--- a/src/commands/join/index.ts
+++ b/src/commands/join/index.ts
@@ -18,11 +18,10 @@ registerCommand({
 	Name: 'join',
 	Description: 'Join a channel. Works only in bots channel',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 20,
 	Params: [],
-	Flags: [ECommandFlags.NoBanphrase],
+	Flags: [ECommandFlags.NoBanphrase, ECommandFlags.ResponseIsReply],
 	PreHandlers: [],
 	Code: async function (ctx) {
 		if (ctx.channel.Name !== Bot.Config.BotUsername) {

--- a/src/commands/leave/index.ts
+++ b/src/commands/leave/index.ts
@@ -26,7 +26,7 @@ registerCommand({
 
 		Bot.Twitch.Controller.RemoveChannelList(ctx.channel.Name);
 		setTimeout(() => {
-			Bot.Twitch.Controller.client.part(ctx.channel.Name);
+			Bot.Twitch.Controller.part(ctx.channel.Name);
 		}, 10000); // Leave after 10 seconds.
 
 		await Bot.SQL.deleteFrom('channels').where('user_id', '=', ctx.channel.Id).execute();

--- a/src/commands/leave/index.ts
+++ b/src/commands/leave/index.ts
@@ -1,5 +1,5 @@
 import Helix from './../../Helix/index.js';
-import { EPermissionLevel } from './../../Typings/enums.js';
+import { ECommandFlags, EPermissionLevel } from './../../Typings/enums.js';
 import { registerCommand } from '../../controller/Commands/Handler.js';
 import TimerSingleton from '../../Singletons/Timers/index.js';
 
@@ -8,11 +8,10 @@ registerCommand({
 	Description:
 		'Leave your channel, works in your channel and the bots channel. All statistics about your channel will be removed.',
 	Permission: EPermissionLevel.BROADCAST,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 5,
 	Params: [],
-	Flags: [],
+	Flags: [ECommandFlags.ResponseIsReply],
 	PreHandlers: [],
 	Code: async function (ctx) {
 		const { channel } = ctx;

--- a/src/commands/markov/index.ts
+++ b/src/commands/markov/index.ts
@@ -30,7 +30,6 @@ registerCommand({
 	Name: 'markov',
 	Description: 'Generate markov chains based of chat',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 5,
 	Params: [[ArgType.String, 'channel']],

--- a/src/commands/ping/index.ts
+++ b/src/commands/ping/index.ts
@@ -14,7 +14,6 @@ registerCommand({
 	Name: 'ping',
 	Description: 'Pings the user with some small info.',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 20,
 	Params: [],

--- a/src/commands/remove/index.ts
+++ b/src/commands/remove/index.ts
@@ -13,7 +13,6 @@ registerCommand<PreHandlers>({
 	Name: 'remove',
 	Description: 'Remove 7TV emotes',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 5,
 	Params: [],

--- a/src/commands/say/index.ts
+++ b/src/commands/say/index.ts
@@ -3,10 +3,8 @@ import { EPermissionLevel } from './../../Typings/enums.js';
 
 registerCommand({
 	Name: 'say',
-	Ping: false,
 	Description: 'Says the direct input.',
 	Permission: EPermissionLevel.ADMIN,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 5,
 	Params: [],

--- a/src/commands/spotify/index.ts
+++ b/src/commands/spotify/index.ts
@@ -36,7 +36,6 @@ const getSongWhipURL = async (spotifyURL: string): Promise<SongWhipResponse> => 
 
 registerCommand({
 	Name: 'spotify',
-	Ping: false,
 	Description: 'Get the currently playing song from Spotify.',
 	Permission: EPermissionLevel.VIEWER,
 	Aliases: [],

--- a/src/commands/spotify/index.ts
+++ b/src/commands/spotify/index.ts
@@ -39,7 +39,6 @@ registerCommand({
 	Ping: false,
 	Description: 'Get the currently playing song from Spotify.',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 5,
 	Params: [[ArgType.String, 'channel']],

--- a/src/commands/suggest/index.ts
+++ b/src/commands/suggest/index.ts
@@ -9,7 +9,6 @@ registerCommand({
 	Name: 'suggest',
 	Description: 'Suggest a new feature or a bug.',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 20,
 	Params: [],

--- a/src/commands/testman/index.ts
+++ b/src/commands/testman/index.ts
@@ -22,7 +22,6 @@ async function Execute(script: string, ctx: TCommandContext): Promise<object | s
 
 registerCommand({
 	Name: 'testman',
-	Ping: false,
 	Description: 'Debug command',
 	Permission: EPermissionLevel.ADMIN,
 	Aliases: ['debug', 'js', 'eval'],

--- a/src/commands/testman/index.ts
+++ b/src/commands/testman/index.ts
@@ -25,7 +25,6 @@ registerCommand({
 	Ping: false,
 	Description: 'Debug command',
 	Permission: EPermissionLevel.ADMIN,
-	OnlyOffline: false,
 	Aliases: ['debug', 'js', 'eval'],
 	Cooldown: 5,
 	Params: [

--- a/src/commands/time/index.ts
+++ b/src/commands/time/index.ts
@@ -5,7 +5,6 @@ import { GetCommandBy, registerCommand } from '../../controller/Commands/Handler
 
 registerCommand({
 	Name: 'time',
-	Ping: false,
 	Description: 'Time a command, similar to the time command in unix',
 	Permission: EPermissionLevel.ADMIN,
 	Aliases: [],

--- a/src/commands/time/index.ts
+++ b/src/commands/time/index.ts
@@ -8,7 +8,6 @@ registerCommand({
 	Ping: false,
 	Description: 'Time a command, similar to the time command in unix',
 	Permission: EPermissionLevel.ADMIN,
-	OnlyOffline: false,
 	Aliases: [],
 	Cooldown: 5,
 	Params: [],

--- a/src/commands/timer/index.ts
+++ b/src/commands/timer/index.ts
@@ -1,4 +1,4 @@
-import { EPermissionLevel } from '../../Typings/enums.js';
+import { ECommandFlags, EPermissionLevel } from '../../Typings/enums.js';
 import { ArgType, TCommandContext } from '../../Models/Command.js';
 import { Result, Ok, Err } from './../../tools/result.js';
 import got from './../../tools/Got.js';
@@ -169,7 +169,6 @@ const actionHandlers: Record<ACTION_TYPE, actionHandler> = {
 
 registerCommand({
 	Name: 'timer',
-	Ping: true,
 	Description: 'Modify chat timers',
 	Permission: EPermissionLevel.MOD,
 	Aliases: ['timers'],
@@ -178,7 +177,7 @@ registerCommand({
 		[ArgType.String, 'interval'],
 		[ArgType.String, 'titles'],
 	],
-	Flags: [],
+	Flags: [ECommandFlags.ResponseIsReply],
 	PreHandlers: [],
 	Code: async function (ctx) {
 		const { input } = ctx;

--- a/src/commands/timer/index.ts
+++ b/src/commands/timer/index.ts
@@ -172,7 +172,6 @@ registerCommand({
 	Ping: true,
 	Description: 'Modify chat timers',
 	Permission: EPermissionLevel.MOD,
-	OnlyOffline: false,
 	Aliases: ['timers'],
 	Cooldown: 5,
 	Params: [

--- a/src/commands/trivia/index.ts
+++ b/src/commands/trivia/index.ts
@@ -4,7 +4,6 @@ import { EPermissionLevel } from './../../Typings/enums.js';
 
 registerCommand({
 	Name: 'trivia',
-	Ping: false,
 	Description:
 		'Initiates a new trivia in the channel, Uses the api created by gazatu at [https://gazatu.xyz]',
 	Permission: EPermissionLevel.VIEWER,

--- a/src/commands/trivia/index.ts
+++ b/src/commands/trivia/index.ts
@@ -8,7 +8,6 @@ registerCommand({
 	Description:
 		'Initiates a new trivia in the channel, Uses the api created by gazatu at [https://gazatu.xyz]',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: ['t'],
 	Cooldown: 5,
 	Params: [

--- a/src/commands/yoink/index.ts
+++ b/src/commands/yoink/index.ts
@@ -14,7 +14,6 @@ registerCommand({
 	Name: 'yoink',
 	Description: 'Steal several 7TV emotes from another channel TriHard ',
 	Permission: EPermissionLevel.VIEWER,
-	OnlyOffline: false,
 	Aliases: ['steal'],
 	Cooldown: 10,
 	Params: [

--- a/src/controller/Channel/index.ts
+++ b/src/controller/Channel/index.ts
@@ -119,18 +119,18 @@ export class Channel {
 	): Promise<void> {
 		if (this.Mode === 'Read') return;
 
-		const client = Bot.Twitch.Controller.client;
+		const controller = Bot.Twitch.Controller;
 
 		let sayFunc: (msg: string) => void;
 		switch (typeof options.ReplyID) {
 			case 'string': {
-				sayFunc = (msg) => client.reply(this.Name, options.ReplyID!, msg);
+				sayFunc = (msg) => controller.reply(this.Name, options.ReplyID!, msg);
 				break;
 			}
 
 			case 'undefined':
 			default: {
-				sayFunc = (msg) => client.privmsg(this.Name, msg);
+				sayFunc = (msg) => controller.say(this.Name, msg);
 			}
 		}
 
@@ -208,7 +208,7 @@ export class Channel {
 		});
 
 		try {
-			await Bot.Twitch.Controller.client.join(user.Name);
+			await Bot.Twitch.Controller.join(user.Name);
 			const channel = await Bot.Twitch.Controller.AddChannelList(user);
 			const resp = await Promise.all([
 				Helix.EventSub.Create('channel.update', {
@@ -238,8 +238,8 @@ export class Channel {
 
 			channel.say('FeelsDankMan 👋 Hi');
 		} catch (err) {
-			await Bot.Twitch.Controller.client.part(user.Name);
-			throw err;
+			await Bot.Twitch.Controller.part(user.Name);
+			throw err; // :tf:
 		}
 	}
 
@@ -265,8 +265,8 @@ export class Channel {
 
 	async UpdateName(newName: string): Promise<void> {
 		try {
-			await Bot.Twitch.Controller.client.part(this.Name);
-			await Bot.Twitch.Controller.client.join(newName);
+			await Bot.Twitch.Controller.part(this.Name);
+			await Bot.Twitch.Controller.join(newName);
 			await Bot.SQL.updateTable('channels')
 				.set({
 					name: newName,
@@ -274,7 +274,7 @@ export class Channel {
 				.where('user_id', '=', this.Id)
 				.execute();
 
-			await Bot.Twitch.Controller.client.part(this.Name);
+			await Bot.Twitch.Controller.part(this.Name);
 			this.Name = newName;
 			await this.say('FeelsDankMan TeaTime');
 		} catch (error) {

--- a/src/controller/Channel/index.ts
+++ b/src/controller/Channel/index.ts
@@ -526,10 +526,13 @@ async function setCommandCooldown(
 	command: string,
 	cooldown: number,
 ): Promise<void> {
-	const key = createCooldownKey(channel, user, command);
+	if (!Bot.Config.Development) {
+		// Disable cooldowns in development
+		const key = createCooldownKey(channel, user, command);
 
-	await Bot.Redis.SSet(key, '1');
-	await Bot.Redis.Expire(key, cooldown);
+		await Bot.Redis.SSet(key, '1');
+		await Bot.Redis.Expire(key, cooldown);
+	}
 }
 
 const cleanMessage = (message: string): string => message.replace(/(\r\n|\n|\r)/gm, ' ');

--- a/src/controller/Channel/index.ts
+++ b/src/controller/Channel/index.ts
@@ -55,11 +55,6 @@ export class Channel {
 	public Mode: PermissionMode;
 
 	/**
-	 * @description Last message in channel.
-	 */
-	public LastMessage: string = '';
-
-	/**
 	 * @description Trivia controller.
 	 */
 	public Trivia: TriviaController | null;
@@ -162,9 +157,6 @@ export class Channel {
 			Bot.Log.Error(error as Error, 'banphraseCheck');
 			sayFunc('FeelsDankMan Banphrase check failed...');
 		}
-
-		// this.Queue.schedule(msg, options);
-		this.LastMessage = msg;
 	}
 
 	/**


### PR DESCRIPTION
Due to the chat client using a connection pool to connect to TMI, it would be receiving the same PRIVMSG on every single connection it had open, rather than the expected x amount of channels per connection. this would mean we would receive the same PRIVMSG multiple times, trying to execute the command multiple times at once, however the lidl cooldown thingy prevented this from breaking anything, Now that it's async it would accidently overlap and execute all the concurrent messages at once. This moves to using the Connection class ourselves. 